### PR TITLE
Add convenience run method

### DIFF
--- a/src/main/java/main/Promise.java
+++ b/src/main/java/main/Promise.java
@@ -63,6 +63,22 @@ public class Promise {
 	}
 
 	/**
+	 * Convenience method to run futures in the same chain without needing a return value.
+	 *
+	 * This is the same as invoking <code>CompletableFuture.runAsync(() -> actionToRun())</code>, but with the
+	 * difference that this method will run the action using the calling thread instead of invoking explicitly a
+	 * separate asynchronous call.
+	 *
+	 * @param actionToRun Action to run
+	 * @param <T> Return type of the supplied action
+	 * @return A {@link CompletableFuture<Void>}<{@link Void}>
+	 */
+	public static <T> CompletableFuture<Void> run(CompletableFuture<T> actionToRun) {
+
+		return actionToRun.thenRun(() -> Promise.none());
+	}
+
+	/**
 	 * Wrap a function returning a CompletableFuture so that any exceptions thrown will get properly propagated as a
 	 * failed future to users of this function. That way users of the function will not have to handle both exceptions
 	 * with regular try-catch logic and handle a failed future.


### PR DESCRIPTION
There are times where you are not interested in the result of a
future, but still you don't want to wrap the function and want to
execute it in a future chain.

With this method you can do that, where the supplied function shall be
executed in the callers thread and return void.

The same can be done by calling CompletableFuture.runAsync but with
the deference that this custom method will run in the callers thread.
If you need to execute something in the common fork join pool, or on
an executors pool, the CF library already provides mechanism for that.