### PR TITLE
Add null checks to most methods

### DIFF
--- a/src/test/java/PromiseTest.java
+++ b/src/test/java/PromiseTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PromiseTest {
@@ -247,6 +248,15 @@ public class PromiseTest {
 
 		assertTrue(intResult.isDone());
 		assertEquals(200, intResult.join().intValue());
+	}
+
+	@Test
+	public void throwNPE() throws Throwable {
+
+		assertThrows(NullPointerException.class, () -> {
+
+			Promise.runUntil(null, 1000, null, null);
+		});
 	}
 
 	private void sleep(long millis) {


### PR DESCRIPTION
The CompletableFuture library has plenty of null checks around its
internal structure, but we as maintainers of the the Promise library
don't actually validate a bunch of the arguments we are given, which
might cause unexpected behavior if not caught early on.