### PR TITLE
Make promise be an extension of CFs

### DIFF
--- a/src/main/java/main/Promise.java
+++ b/src/main/java/main/Promise.java
@@ -32,13 +32,12 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import javax.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Promise {
+public class Promise<T> extends CompletableFuture<T> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Promise.class);
 
@@ -245,12 +244,6 @@ public class Promise {
 		}, atMostTimeout, unit);
 	}
 
-	@SafeVarargs
-	public static <T> CompletableFuture<List<T>> allOf(CompletableFuture<T>... futures) {
-
-		return allOf(Arrays.asList(futures));
-	}
-
 	public static <T> CompletableFuture<List<T>> allOf(@NotNull Collection<CompletableFuture<T>> futures) {
 
 		if (futures == null)
@@ -400,7 +393,7 @@ public class Promise {
 		if (functionToRunAfterActions == null)
 			throw new NullPointerException("Function must not be null");
 
-		return allOf(Promise.of(action1), Promise.of(action2))
+		return allOf(Arrays.asList(Promise.of(action1), Promise.of(action2)))
 				// We are implicitly guaranteed that the actions cannot be less (or more) than 2, thus avoiding IOOB Ex
 				.thenApply(actions -> functionToRunAfterActions.apply(actions.get(0), actions.get(1)).join());
 	}
@@ -427,7 +420,7 @@ public class Promise {
 		if (functionToRunAfterActions == null)
 			throw new NullPointerException("Function must not be null");
 
-		return allOf(future1, future2)
+		return allOf(Arrays.asList(future1, future2))
 				// We are implicitly guaranteed that the actions cannot be less (or more) than 2, thus avoiding IOOB Ex
 				.thenApply(results -> functionToRunAfterActions.apply(results.get(0), results.get(1)).join());
 	}

--- a/src/main/java/main/Promise.java
+++ b/src/main/java/main/Promise.java
@@ -41,14 +41,29 @@ public class Promise<T> extends CompletableFuture<T> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Promise.class);
 
-	public static <T> CompletableFuture<T> none() {
+	public Promise() {}
+
+	public static <V> CompletableFuture<V> none() {
 
 		return completed(null);
+	}
+
+	public Promise<T> nil() {
+
+		complete(null);
+		return this;
 	}
 
 	public static <T> CompletableFuture<Optional<T>> empty() {
 
 		return completed(Optional.empty());
+	}
+
+	public static <V> Promise<Optional<V>> blank() {
+
+		Promise<Optional<V>> p = new Promise<>();
+		p.complete(Optional.empty());
+		return p;
 	}
 
 	public static <T> CompletableFuture<T> completed(T t) {
@@ -61,6 +76,12 @@ public class Promise<T> extends CompletableFuture<T> {
 		CompletableFuture<T> cf = new CompletableFuture<>();
 		cf.completeExceptionally(e);
 		return cf;
+	}
+
+	public Promise<T> abort(Throwable e) {
+
+		this.completeExceptionally(e);
+		return this;
 	}
 
 	/**

--- a/src/test/java/PromiseTest.java
+++ b/src/test/java/PromiseTest.java
@@ -17,6 +17,7 @@
  */
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +37,33 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PromiseTest {
 
 	@Test
-	void promiseRetryCancel() throws Exception {
+	void nil() throws Exception {
+
+		Promise<Void> p = new Promise<>();
+		p.nil();
+
+		assertNull(p.join());
+	}
+
+	@Test
+	void blank() throws Exception {
+
+		Promise<Optional<Object>> blank = Promise.blank();
+
+		assertFalse(blank.join().isPresent());
+	}
+
+	@Test
+	void abort() throws Throwable {
+
+		Promise<Void> p = new Promise<>();
+		p.abort(new NullPointerException());
+
+		assertThrows(CompletionException.class, () -> p.join());
+	}
+
+	@Test
+	public void promiseRetryCancel() throws Exception {
 
 		final int[] numFails = { 0 };
 		final int sleepMs = 500;


### PR DESCRIPTION
Although the library itself only adds static methods, it makes sense
that itself in the future might be used as an extension of the
original Completablefutures and that it can be extended to add on top
of the already existing API, more functionality.